### PR TITLE
Added delete cascade for spy_cms_page_store relation table.

### DIFF
--- a/src/Spryker/Zed/Cms/Persistence/Propel/Schema/spy_cms.schema.xml
+++ b/src/Spryker/Zed/Cms/Persistence/Propel/Schema/spy_cms.schema.xml
@@ -99,7 +99,7 @@
             <unique-column name="fk_store"/>
         </unique>
 
-        <foreign-key name="spy_cms_page_store-fk_cms_page" foreignTable="spy_cms_page">
+        <foreign-key name="spy_cms_page_store-fk_cms_page" foreignTable="spy_cms_page" onDelete="CASCADE">
             <reference local="fk_cms_page" foreign="id_cms_page"/>
         </foreign-key>
         <foreign-key name="spy_cms_page_store-fk_store" foreignTable="spy_store">


### PR DESCRIPTION
Currently you can't delete CMS Pages by the CMS facade as there is a missing delete cascade.

So I added that cascade to the propel definition.